### PR TITLE
Allow to report syntax errors using LSP error and/or "window/showMessage" notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,21 +102,13 @@ following ways:
 
 Additional keys in LSP initialization options can be used to influence the LSP server behavior. See the docs of your LSP client (text editor) to know how to pass initialization options.
 
-- `syntaxErrorCausesLspError` (boolean, behaves as `false` if not specified) : Report LSP error on syntax error when parsing Pascal file.
+- `syntaxErrorReportingMode` (integer): Determines how to report syntax errors. Syntax errors indicate that CodeTools cannot understand the surrounding Pascal code well enough to provide any code completion.
 
-     By default, when this is `false`, the LSP server answers with a fake completion item with the error message. While it is a hack (we use completion item label to pass the error message), it works in VS Code and NeoVim.
+    - 0 (default): Return a fake completion item with the error message. This works well in VC Code and NeoVim -- while the completion item doesn't really complete anything, but the error message is clearly visible.
 
-     When this is `true`, the LSP server answers with LSP error. This is visible in Emacs.
+    - 1: Show an error message. This relies on the LSP client (text editor) handling the `window/showMessage` message. This works well in VS Code, and somewhat works in Emacs (Emacs `lsp-mode` handles and shows the message, though it will usually be quickly hidden by the next message _"No completion item"_ and you'll have to look at it in the `*Messages*` buffer).
 
-- `syntaxErrorCausesShowMessage` (boolean, behaves as `true` if not specified) : Report a "show message" to LSP client on syntax error when parsing Pascal file.
-
-     Note that this is independent from `syntaxErrorCausesLspError`. Regardless `syntaxErrorCausesLspError` (whether we respond with LSP error or fake item), we can also invoke a "show message" on LSP client.
-
-     The effect of this depends on how the LSP client respects the `window/showMessage`.
-
-     - VS Code shows it nicely.
-
-     - Emacs shows it (but poorly, it will be quickly obscured by the message about lack of completions, and you will need to go to the `*Messages*` buffer to read it).
+    - 2: Return an error to the LSP client. Some LSP clients will just hide the error, but some (like Emacs) will show it clearly and prominently.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,26 @@ following ways:
 
    This overrides environment variables.
 
+## Extra configuration in LSP initialization options
+
+Additional keys in LSP initialization options can be used to influence the LSP server behavior. See the docs of your LSP client (text editor) to know how to pass initialization options.
+
+- `syntaxErrorCausesLspError` (boolean, behaves as `false` if not specified) : Report LSP error on syntax error when parsing Pascal file.
+
+     By default, when this is `false`, the LSP server answers with a fake completion item with the error message. While it is a hack (we use completion item label to pass the error message), it works in VS Code and NeoVim.
+
+     When this is `true`, the LSP server answers with LSP error. This is visible in Emacs.
+
+- `syntaxErrorCausesShowMessage` (boolean, behaves as `true` if not specified) : Report a "show message" to LSP client on syntax error when parsing Pascal file.
+
+     Note that this is independent from `syntaxErrorCausesLspError`. Regardless `syntaxErrorCausesLspError` (whether we respond with LSP error or fake item), we can also invoke a "show message" on LSP client.
+
+     The effect of this depends on how the LSP client respects the `window/showMessage`.
+
+     - VS Code shows it nicely.
+
+     - Emacs shows it (but poorly, it will be quickly obscured by the message about lack of completions, and you will need to go to the `*Messages*` buffer to read it).
+
 ## Roadmap
 
 ### Wishlist

--- a/README.md
+++ b/README.md
@@ -47,7 +47,13 @@ For information on how to use the server from Neovim, see [client/nvim](client/n
 
 To use the server from `lsp-mode` in Emacs, install the separate
 [`lsp-pascal`](https://github.com/arjanadriaanse/lsp-pascal) module.
-(Disclaimer: I don't maintain this and have not tested it as I don't use Emacs)
+Full example setup of it is documented in [Michalis notes about LSP + Pascal](https://github.com/michaliskambi/elisp/tree/master/lsp).
+
+### VS Code
+
+Install the VS Code extension from https://github.com/genericptr/pasls-vscode .
+
+Note that the extension settings expose some additional LSP options not understood by this LSP server. But the basic ones (FPC, Lazarus configs and the executable of LSP server) work completely fine with this LSP server.
 
 ### Other
 Any editor that allows you to add custom LSP configurations should work.

--- a/README.md
+++ b/README.md
@@ -104,9 +104,15 @@ Additional keys in LSP initialization options can be used to influence the LSP s
 
 - `syntaxErrorReportingMode` (integer): Determines how to report syntax errors. Syntax errors indicate that CodeTools cannot understand the surrounding Pascal code well enough to provide any code completion.
 
-    - 0 (default): Return a fake completion item with the error message. This works well in VC Code and NeoVim -- while the completion item doesn't really complete anything, but the error message is clearly visible.
+    - 0 (default): Show an error message. This relies on the LSP client (text editor) handling the `window/showMessage` message. Support in various text editor:
 
-    - 1: Show an error message. This relies on the LSP client (text editor) handling the `window/showMessage` message. This works well in VS Code, and somewhat works in Emacs (Emacs `lsp-mode` handles and shows the message, though it will usually be quickly hidden by the next message _"No completion item"_ and you'll have to look at it in the `*Messages*` buffer).
+        - VS Code: works.
+
+        - NeoVim (0.8.0): works, the message is shown for ~1 sec by default.
+
+        - Emacs: works, the message is visible in [echo area](https://www.emacswiki.org/emacs/EchoArea) and the `*Messages*` buffer. You can filter out useless `No completion found` messages to make it perfect, see https://github.com/michaliskambi/elisp/blob/master/lsp/kambi-pascal-lsp.el for example.
+
+    - 1: Return a fake completion item with the error message. This works well in VC Code and NeoVim -- while the completion item doesn't really complete anything, but the error message is clearly visible.
 
     - 2: Return an error to the LSP client. Some LSP clients will just hide the error, but some (like Emacs) will show it clearly and prominently.
 

--- a/server/uinitialize.pas
+++ b/server/uinitialize.pas
@@ -34,7 +34,7 @@ implementation
 uses
   SysUtils, Classes, CodeToolManager, CodeToolsConfig, URIParser, LazUTF8,
   DefineTemplates, FileUtil, LazFileUtils, DOM, XMLRead, udebug, uutils,
-  upackages;
+  upackages, utextdocument;
 
 
 // Resolve the dependencies of Pkg, and then the dependencies of the
@@ -536,6 +536,7 @@ var
   Options:   TCodeToolsOptions;
   Key:       string;
   s:         string;
+  b:         Boolean;
 
   RootUri:   string;
   Directory: string;
@@ -587,7 +588,11 @@ begin
             else if (Key = 'FPCTARGET') and Reader.Str(s) then
               Options.TargetOS := s
             else if (Key = 'FPCTARGETCPU') and Reader.Str(s) then
-              Options.TargetProcessor := s;
+              Options.TargetProcessor := s
+            else if (Key = 'syntaxErrorCausesLspError') and Reader.Bool(b) then
+              SyntaxErrorCausesLspError := b
+            else if (Key = 'syntaxErrorCausesShowMessage') and Reader.Bool(b) then
+              SyntaxErrorCausesShowMessage := b;
           end;
       end;
 

--- a/server/uinitialize.pas
+++ b/server/uinitialize.pas
@@ -532,11 +532,21 @@ begin
 end;
 
 procedure Initialize(Rpc: TRpcPeer; Request: TRpcRequest);
+
+  function SyntaxErrorReportingModeFromInt(const I: Integer): TSyntaxErrorReportingMode;
+  begin
+    if (I < Ord(Low(TSyntaxErrorReportingMode))) or
+       (I > Ord(High(TSyntaxErrorReportingMode))) then
+      raise Exception.CreateFmt('Invalid syntaxErrorReportingMode: %d, ignoring', [I]);
+
+    Result := TSyntaxErrorReportingMode(I)
+  end;
+
 var
   Options:   TCodeToolsOptions;
   Key:       string;
   s:         string;
-  b:         Boolean;
+  i:         Integer;
 
   RootUri:   string;
   Directory: string;
@@ -589,10 +599,8 @@ begin
               Options.TargetOS := s
             else if (Key = 'FPCTARGETCPU') and Reader.Str(s) then
               Options.TargetProcessor := s
-            else if (Key = 'syntaxErrorCausesLspError') and Reader.Bool(b) then
-              SyntaxErrorCausesLspError := b
-            else if (Key = 'syntaxErrorCausesShowMessage') and Reader.Bool(b) then
-              SyntaxErrorCausesShowMessage := b;
+            else if (Key = 'syntaxErrorReportingMode') and Reader.Number(i) then
+              SyntaxErrorReportingMode := SyntaxErrorReportingModeFromInt(i);
           end;
       end;
 

--- a/server/ujsonrpc.pas
+++ b/server/ujsonrpc.pas
@@ -295,7 +295,6 @@ begin
     Result.Id      := Id;
     Result.Reader  := Reader;
     Result.FBuffer := Buffer;
-    Result.Reader  := Reader;
 
     DebugLog('> Request: '#10'%s', [Copy(Result.AsString, 1, 2000)]);
   except

--- a/server/utextdocument.pas
+++ b/server/utextdocument.pas
@@ -29,13 +29,13 @@ uses
 
 type
   TSyntaxErrorReportingMode = (
-    sermFakeCompletionItem = 0,
-    sermShowMessage = 1,
+    sermShowMessage = 0,
+    sermFakeCompletionItem = 1,
     sermErrorResponse = 2
   );
 
 var
-  SyntaxErrorReportingMode: TSyntaxErrorReportingMode = sermFakeCompletionItem;
+  SyntaxErrorReportingMode: TSyntaxErrorReportingMode = sermShowMessage;
 
 procedure TextDocument_DidOpen(Rpc: TRpcPeer; Request: TRpcRequest);
 procedure TextDocument_DidChange(Rpc: TRpcPeer; Request: TRpcRequest);

--- a/server/utextdocument.pas
+++ b/server/utextdocument.pas
@@ -318,20 +318,27 @@ end;
 
 procedure TextDocument_Completion(Rpc: TRpcPeer; Request: TRpcRequest);
 
-  function ShowErrorMessage(const ErrorMessage: String): TRpcNotification;
+  procedure ShowErrorMessage(const ErrorMessage: String);
   var
-    Writer:   TJsonWriter;
+    Writer: TJsonWriter;
+    MessageNotification: TRpcResponse;
   begin
-    Result := TRpcNotification.Create('window/showMessage');
-    Writer := Result.Writer;
+    MessageNotification := TRpcResponse.CreateNotification('window/showMessage');
+    try
+      Writer := MessageNotification.Writer;
 
-    Writer.Key('params');
-    Writer.Dict;
-      Writer.Key('type');
-      Writer.Number(1); // type = 1 means "error"
-      Writer.Key('message');
-      Writer.Str(ErrorMessage);
-    Writer.DictEnd;
+      Writer.Key('params');
+      Writer.Dict;
+        Writer.Key('type');
+        Writer.Number(1); // type = 1 means "error"
+        Writer.Key('message');
+        Writer.Str(ErrorMessage);
+      Writer.DictEnd;
+
+      Rpc.Send(MessageNotification);
+    finally
+      FreeAndNil(MessageNotification);
+    end;
   end;
 
 var
@@ -418,7 +425,7 @@ begin
         Rpc.Send(Response);
 
         if SyntaxErrorCausesShowMessage then
-          Rpc.Send(ShowErrorMessage(E.Message));
+          ShowErrorMessage(E.Message);
       end;
     end;
   finally


### PR DESCRIPTION
Looking for a perfect way to report Pascal syntax errors (easily caused by missing Pascal units), this PR gives users 2 new ways to see error:

- `window/showMessage` . This is supported by VS Code nicely, by Emacs too (but poorly). It is by default `true` (as it seems to do no harm, in the worst case clients that don't support it will just ignore it).

- by returning LSP error instead of a "fake completion item". The fake completion item works poorly in Emacs, the LSP error is visible nicer. It is by default `false` to not break previous behavior. Emacs users may likely prefer to turn this on.

Both these can be controlled by new `syntaxErrorCausesLspError`, `syntaxErrorCausesShowMessage` flags that clients can pass as LSP initialization options.

The options are documented in README.md.

See https://github.com/michaliskambi/elisp/issues/1 for various details about Emacs.

Codewise, I have introduced 2 new classes: `TRpcNotification` and `TRpcMessageToClient` (common ancestor for `TRpcNotification` and `TRpcResponse`). `window/showMessage` is a "notification" in JSON-RPC sense (see https://www.jsonrpc.org/specification#notification ) and it seemed cleanest to express it as a new class (rather then overusing `TRpcResponse`). Following JSON-RPC ver 2 spec, "notifications" differ from "responses" in that:

- Notifications do not pass any id. (Trying to pass `id` with `window/showMessage` was leading to weirdest errors from both VS Code and Emacs :) ).

- The other side (LSP client in this case) is not supposed to reply. This is nice, it means we don't have to handle anything extra (no need to dispatch some LSP client answer) to support `window/showMessage`.

BTW 2 fixes:

- fake completion item contains `isIncomplete`, as required by LSP spec. Without it, Emacs throws scary Lisp error.

- I noticed that `TRpcPeer.Receive` has accidentally `Result.Reader := Reader` assignment 2 times.
