### PR TITLE
Fix for working with subfolders that contain source code in the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/backup/
-/lib/
+**/lib/
+**/backup/
 *.lps

--- a/server/pasls.lpi
+++ b/server/pasls.lpi
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CONFIG>
   <ProjectOptions>
-    <Version Value="11"/>
+    <Version Value="12"/>
     <General>
       <Flags>
         <MainUnitHasCreateFormStatements Value="False"/>
+        <CompatibilityMode Value="True"/>
       </Flags>
       <SessionStorage Value="InProjectDir"/>
-      <MainUnit Value="0"/>
       <Title Value="pasls"/>
       <UseAppBundle Value="False"/>
       <ResourceType Value="res"/>
@@ -42,25 +42,27 @@
     </PublishOptions>
     <RunParams>
       <FormatVersion Value="2"/>
-      <Modes Count="0"/>
     </RunParams>
-    <RequiredPackages Count="5">
+    <RequiredPackages Count="6">
       <Item1>
-        <PackageName Value="jsonstreampkg"/>
-        <DefaultFilename Value="deps/jsonstream/pascal/package/jsonstreampkg.lpk" Prefer="True"/>
+        <PackageName Value="LazUtils"/>
       </Item1>
       <Item2>
-        <PackageName Value="LCLBase"/>
+        <PackageName Value="jsonstreampkg"/>
+        <DefaultFilename Value="deps/jsonstream/pascal/package/jsonstreampkg.lpk" Prefer="True"/>
       </Item2>
       <Item3>
-        <PackageName Value="CodeTools"/>
+        <PackageName Value="LCLBase"/>
       </Item3>
       <Item4>
-        <PackageName Value="WebLaz"/>
+        <PackageName Value="CodeTools"/>
       </Item4>
       <Item5>
-        <PackageName Value="FCL"/>
+        <PackageName Value="WebLaz"/>
       </Item5>
+      <Item6>
+        <PackageName Value="FCL"/>
+      </Item6>
     </RequiredPackages>
     <Units Count="8">
       <Unit0>

--- a/server/pasls.lpi
+++ b/server/pasls.lpi
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CONFIG>
   <ProjectOptions>
-    <Version Value="12"/>
+    <Version Value="11"/>
     <General>
       <Flags>
         <MainUnitHasCreateFormStatements Value="False"/>
-        <CompatibilityMode Value="True"/>
       </Flags>
       <SessionStorage Value="InProjectDir"/>
+      <MainUnit Value="0"/>
       <Title Value="pasls"/>
       <UseAppBundle Value="False"/>
       <ResourceType Value="res"/>
@@ -42,26 +42,27 @@
     </PublishOptions>
     <RunParams>
       <FormatVersion Value="2"/>
+      <Modes Count="0"/>
     </RunParams>
-    <RequiredPackages Count="6">
+    <RequiredPackages Count="5">
       <Item1>
-        <PackageName Value="LazUtils"/>
-      </Item1>
-      <Item2>
         <PackageName Value="jsonstreampkg"/>
         <DefaultFilename Value="deps/jsonstream/pascal/package/jsonstreampkg.lpk" Prefer="True"/>
+      </Item1>
+      <Item2>
+        <PackageName Value="LCLBase"/>
       </Item2>
       <Item3>
-        <PackageName Value="LCLBase"/>
+        <PackageName Value="CodeTools"/>
       </Item3>
       <Item4>
-        <PackageName Value="CodeTools"/>
+        <PackageName Value="WebLaz"/>
       </Item4>
       <Item5>
-        <PackageName Value="WebLaz"/>
+        <PackageName Value="FCL"/>
       </Item5>
       <Item6>
-        <PackageName Value="FCL"/>
+        <PackageName Value="LazUtils"/>
       </Item6>
     </RequiredPackages>
     <Units Count="8">

--- a/server/upackages.pas
+++ b/server/upackages.pas
@@ -149,9 +149,9 @@ end;
 
 procedure LoadPackageOrProject(const FileName: string);
 var
-  Doc:                                           TXMLDocument;
-  Root, Temp, CompilerOptions, RequiredPackages: TDomNode;
-  Package:                                       TPackage;
+  Doc:                                     TXMLDocument;
+  Root, CompilerOptions, RequiredPackages: TDomNode;
+  Package:                                 TPackage;
 
   function GetAdditionalPaths(
     SearchPaths: TDomNode; const What: string

--- a/server/upackages.pas
+++ b/server/upackages.pas
@@ -282,9 +282,7 @@ begin
         Exit;
 
       if UpperCase(ExtractFileExt(FileName)) = '.LPK' then
-        Root := Root.FindNode('Package')
-      else
-        Root := Root.FindNode('ProjectOptions');
+        Root := Root.FindNode('Package');
 
       if not Assigned(Root) then
         Exit;


### PR DESCRIPTION
When I tried to work with a project that contained subfolders with other units inside, pasls reported an error that a certain unit could not be found. This happens when we add a new unit to a folder, but we do not add the unit to the .lpi project file.

Checking a new project created by Lazarus, I noticed that the <CompilerOptions> node is always at the same level as the <ProjectOptions> node. The code responsible for building the list of folders for searching ends up not locating the <CompilerOptions> node that contains the configuration of folders to be passed as parameters to CodeTools.

I have tested projects with more than one build mode, and when we create other build modes in the Lazarus IDE, the build mode marked "Active" is always in the <CompilerOptions> node at the same level as <ProjectOptions>.

My suggestion is to simply not use FindNode('ProjectOptions') so that the <CompilerOptions> node configured as "Active" is the one selected by the pascal language server. Code for .lpk projects is not impacted by this change.

I made this change and tested the extension in vscode/windows and it worked.

I don't know if this is the best way to address this problem. If not, please let me know.

Thanks.