### PR TITLE
Fix compilation with LCL >= 3.0.0, needs SortMethodForCompletion instead of SortForScope

### DIFF
--- a/server/uinitialize.pas
+++ b/server/uinitialize.pas
@@ -33,8 +33,8 @@ implementation
 
 uses
   SysUtils, Classes, CodeToolManager, CodeToolsConfig, URIParser, LazUTF8,
-  DefineTemplates, FileUtil, LazFileUtils, DOM, XMLRead, udebug, uutils,
-  upackages, utextdocument;
+  DefineTemplates, FileUtil, LazFileUtils, LCLVersion, IdentCompletionTool,
+  DOM, XMLRead, udebug, uutils, upackages, utextdocument;
 
 
 // Resolve the dependencies of Pkg, and then the dependencies of the
@@ -636,7 +636,17 @@ begin
     begin
       Init(Options);
       IdentifierList.SortForHistory := True;
+      { LCL changed in
+        https://gitlab.com/freepascal.org/lazarus/lazarus/-/commit/de3a85ac41a2f882500c2d479dff48bd7bbec7f1 ,
+        removing SortForScope (Boolean), 
+        adding instead SortMethodForCompletion (enum).
+        The SortMethodForCompletion=icsScopedAlphabetic seems to be the equivalent 
+        of the old SortForScope=True. }
+      {$if LCL_FULLVERSION >= 3000000}
+      IdentifierList.SortMethodForCompletion := icsScopedAlphabetic;
+      {$else}
       IdentifierList.SortForScope   := True;
+      {$endif}
     end;
 
     // Load packages into our internal database and resolve dependencies


### PR DESCRIPTION
LCL changed in https://gitlab.com/freepascal.org/lazarus/lazarus/-/commit/de3a85ac41a2f882500c2d479dff48bd7bbec7f1 , removing SortForScope (Boolean), adding instead SortMethodForCompletion (enum).

This PR fixes the compilation with LCL >= 3.0.0, using `LCL_FULLVERSION`.